### PR TITLE
git ignore update + batch size limited to 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ ModelManifest.xml
 
 # Visual Studio data
 .vs/
+
+.idea/
+.DS_Store

--- a/MongoDb/Microsoft.DataTransfer.MongoDb/Source/Online/MongoDbSourceAdapter.cs
+++ b/MongoDb/Microsoft.DataTransfer.MongoDb/Source/Online/MongoDbSourceAdapter.cs
@@ -53,6 +53,12 @@ namespace Microsoft.DataTransfer.MongoDb.Source.Online
                         new MongoClient(url)
                             .GetDatabase(url.DatabaseName)
                             .GetCollection<BsonDocument>(configuration.Collection);
+
+                    if(options == null)
+                    {
+                        options = new FindOptions<BsonDocument, BsonDocument>();
+                        options.BatchSize = 10;
+                    }
                     
                     var mongoCursor = String.IsNullOrEmpty(configuration.Query) 
                         ? collection.FindAsync(


### PR DESCRIPTION
in the case of having large documents and putting query into the solution, we can exceed the limit of 40 mbs which is set for older cosmos db databases. limiting the batch size fixes that issue as long as 10 documents are not exceeding the size of 40mb